### PR TITLE
Use environment variable for Django secret key

### DIFF
--- a/App_Huellita/settings.py
+++ b/App_Huellita/settings.py
@@ -21,10 +21,16 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-!9_g9vcq)iom1nkf7pm6ab((o#^nib6*+&pawru7o^(!31_ud8'
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'unsafe-default')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+
+# If DEBUG is False and the secret key wasn't provided, fail fast.
+if not DEBUG and SECRET_KEY == 'unsafe-default':
+    raise RuntimeError(
+        "DJANGO_SECRET_KEY environment variable must be set when DEBUG is False"
+    )
 
 ALLOWED_HOSTS = []
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Huellitas GC
+
+This project is a Django application. When running in production, make sure to define the following environment variable:
+
+- `DJANGO_SECRET_KEY`: secret key used by Django for cryptographic signing.
+  If the variable is not set and `DEBUG` is `False`, the application will raise
+  a `RuntimeError` during startup. When `DEBUG` is `True`, a default unsafe
+  value is used.
+


### PR DESCRIPTION
## Summary
- pull the Django secret key from `DJANGO_SECRET_KEY`
- raise an error when no key is set in production
- document the environment variable in `README.md`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ae659464883209d092dedd8680ca5